### PR TITLE
Fix adding multiple changelog entries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Validate the new changelog files (yaml format)
       run: |
         filenames=$(git diff --name-only --diff-filter=A HEAD^ HEAD | grep 'releases/unreleased')
-        echo $filenames | while read filename;
+        echo "$filenames" | while read filename;
         do
           echo -n "$filename: "
           if ! [ -s $filename ]; then


### PR DESCRIPTION
This PR fixes when adding multiple changelog entries in the same pull request.

This PR fixes the error https://github.com/Bitergia/release-tools/runs/7432808462 where the action fails because there is more than one changelog entry.