### PR TITLE
[actions] Include SHA version of the action used

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Verify if the PR includes a new changelog entry'
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
       with:
           fetch-depth: 2
 
@@ -12,7 +12,7 @@ runs:
       shell: bash
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: 3.8
 


### PR DESCRIPTION
This commit updates the version number of the actions being used. Now they will use the commit SHA of a released action version because it is the best for stability and security.

Signed-off-by: Jose Javier Merchante <jjmerchante@bitergia.com>